### PR TITLE
feat: add crates.io/cargo-run-script

### DIFF
--- a/pkgs/crates.io/cargo-run-script/pkg.yaml
+++ b/pkgs/crates.io/cargo-run-script/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: crates.io/cargo-run-script@0.2.0

--- a/pkgs/crates.io/cargo-run-script/registry.yaml
+++ b/pkgs/crates.io/cargo-run-script/registry.yaml
@@ -1,0 +1,7 @@
+packages:
+  - name: crates.io/cargo-run-script
+    type: cargo
+    repo_owner: JoshMcguigan
+    repo_name: cargo-run-script
+    description: Bringing `npm run-script` to Rust
+    crate: cargo-run-script

--- a/registry.yaml
+++ b/registry.yaml
@@ -13020,6 +13020,12 @@ packages:
     description: A new file manager
     link: https://dystroy.org/broot
     crate: broot
+  - name: crates.io/cargo-run-script
+    type: cargo
+    repo_owner: JoshMcguigan
+    repo_name: cargo-run-script
+    description: Bringing `npm run-script` to Rust
+    crate: cargo-run-script
   # TODO: Merge this package with eza-community/eza
   # https://github.com/aquaproj/aqua/issues/2649
   - name: crates.io/eza


### PR DESCRIPTION
[crates.io/cargo-run-script](https://github.com/crates.io/cargo-run-script): Bringing `npm run-script` to Rust

```console
$ aqua g -i crates.io/cargo-run-script
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ 
```

If files such as configuration file are needed, please share them.

```
```

Reference

-
